### PR TITLE
Improved JS framework configuration

### DIFF
--- a/environment.rb
+++ b/environment.rb
@@ -13,4 +13,3 @@ ActiveRecord::Base.class_eval     {include ActiveRecordPermissions::ModelUserAcc
 ActiveRecord::Base.class_eval     {include ActiveRecordPermissions::Permissions}
 
 I18n.load_path += Dir[File.join(File.dirname(__FILE__), 'lib', 'active_scaffold', 'locale', '*.{rb,yml}')]
-#ActiveScaffold.js_framework = :jquery

--- a/init.rb
+++ b/init.rb
@@ -12,7 +12,9 @@ require File.dirname(__FILE__) + '/environment'
 ## But at least rescue the action in production
 ##
 begin
-  require File.dirname(__FILE__) + '/install_assets'
+  %w{assets initializer}.each do |installer|
+    require File.join(File.dirname(__FILE__), "install_#{installer}")
+  end
 rescue
   raise $! unless Rails.env == 'production'
 end

--- a/install.rb
+++ b/install.rb
@@ -1,10 +1,4 @@
 ##
-## Install ActiveScaffold assets into /public 
-##
-
-require File.dirname(__FILE__) + '/install_assets'
-
-##
 ## Install Counter
 ##
 #

--- a/install_assets.rb
+++ b/install_assets.rb
@@ -2,44 +2,48 @@
 # See http://dev.rubyonrails.org/ticket/8189
 Dir.chdir(Dir.getwd.sub(/vendor.*/, '')) do
 
-##
-## Copy over asset files (javascript/css/images) from the plugin directory to public/
-##
+  ##
+  ## Copy over asset files (javascript/css/images) from the plugin directory to public/
+  ##
+  def copy_files(source_path, destination_path, directory, file_mask = '*.*', clean_up_destination = false)
+    source, destination = File.join(directory, source_path), File.join(Rails.root, destination_path)
+    
+    FileUtils.rm_rf Dir.glob("#{destination}") if clean_up_destination
+    FileUtils.mkdir_p(destination) unless File.exist?(destination)
 
-def copy_files(source_path, destination_path, directory, file_mask = '*.*', clean_up_destination = false)
-  source, destination = File.join(directory, source_path), File.join(Rails.root, destination_path)
-  FileUtils.mkdir_p(destination) unless File.exist?(destination)
-  Dir.glob('*.so')
+    # What is that??
+    Dir.glob('*.so')
 
-  FileUtils.rm Dir.glob("#{destination}/*") if clean_up_destination
-  FileUtils.cp_r(Dir.glob("#{source}/#{file_mask}"), destination)
-end
+    FileUtils.cp_r(Dir.glob("#{source}/#{file_mask}"), destination)
+  end
 
-directory = File.dirname(__FILE__)
+  directory = File.dirname(__FILE__)
 
-copy_files("/public", "/public", directory)
+  copy_files("/public", "/public", directory)
 
-available_frontends = Dir[File.join(directory, 'frontends', '*')].collect { |d| File.basename d }
-[ :stylesheets, :javascripts, :images].each do |asset_type|
-  path = "/public/#{asset_type}/active_scaffold"
-  copy_files(path, path, directory)
+  available_frontends = Dir[File.join(directory, 'frontends', '*')].collect { |d| File.basename d }
+  [ :stylesheets, :javascripts, :images].each do |asset_type|
+    path = "/public/#{asset_type}/active_scaffold"
+    copy_files(path, path, directory)
   
-  File.open(File.join(Rails.root, path, 'DO_NOT_EDIT'), 'w') do |f|
-    f.puts "Any changes made to files in sub-folders will be lost."
-    f.puts "See http://activescaffold.com/tutorials/faq#custom-css."
-  end
-
-  available_frontends.each do |frontend|
-    if asset_type == :javascripts
-      file_mask = '*.js'
-      source = "/frontends/#{frontend}/#{asset_type}/#{ActiveScaffold.js_framework}"
-    else
-      file_mask = '*.*'
-      source = "/frontends/#{frontend}/#{asset_type}"
+    File.open(File.join(Rails.root, path, 'DO_NOT_EDIT'), 'w') do |f|
+      f.puts "Any changes made to files in sub-folders will be lost."
+      f.puts "See http://activescaffold.com/tutorials/faq#custom-css."
     end
-    destination = "/public/#{asset_type}/active_scaffold/#{frontend}"
-    copy_files(source, destination, directory, file_mask, true)
-  end
-end
 
+    available_frontends.each do |frontend|
+      if asset_type == :javascripts
+        # Make both Prototype and jQuery includes available,
+        # choice will be made at include time
+        file_mask = ''
+        source = "/frontends/#{frontend}/#{asset_type}/*"
+      else
+        file_mask = '*.*'
+        source = "/frontends/#{frontend}/#{asset_type}"
+      end
+
+      destination = "/public/#{asset_type}/active_scaffold/#{frontend}"
+      copy_files(source, destination, directory, file_mask, true)
+    end
+  end
 end

--- a/install_initializer.rb
+++ b/install_initializer.rb
@@ -1,0 +1,9 @@
+# Creates an initializer if it doesn't already exist
+initializer = File.join(Rails.root, 'config', 'initializers', 'active_scaffold.rb')
+
+unless File.exist? initializer
+  File.open(initializer, 'w') do |f|
+    f.puts "# Available options are :prototype and :jquery"
+    f.puts "ActiveScaffold.js_framework = :prototype"
+  end
+end

--- a/lib/active_scaffold.rb
+++ b/lib/active_scaffold.rb
@@ -46,11 +46,21 @@ module ActiveScaffold
   end
   
   def self.js_framework=(framework)
+    frameworks = [:jquery, :prototype]
+
+    unless frameworks.include? framework
+      raise "Invalid JavaScript framework : #{framework}. Available options are #{frameworks.to_sentence}"
+    end
+
     @@js_framework = framework
   end
   
   def self.js_framework
-    @@js_framework ||= :prototype
+    unless class_variable_defined? :@@js_framework
+      raise "You have to configure ActiveScaffold to use either Prototype or jQuery as a JavaScript framework"
+    end
+
+    @@js_framework
   end
 
   module ClassMethods

--- a/lib/active_scaffold/config/core.rb
+++ b/lib/active_scaffold/config/core.rb
@@ -214,13 +214,13 @@ module ActiveScaffold::Config
     # must be a class method so the layout doesn't depend on a controller that uses active_scaffold
     # note that this is unaffected by per-controller frontend configuration.
     def self.asset_path(filename, frontend = self.frontend)
-      "active_scaffold/#{frontend}/#{filename}"
+      File.join('active_scaffold', frontend.to_s, filename)
     end
 
     # must be a class method so the layout doesn't depend on a controller that uses active_scaffold
     # note that this is unaffected by per-controller frontend configuration.
     def self.javascripts(frontend = self.frontend)
-      javascript_dir = File.join(Rails.public_path, "javascripts", asset_path('', frontend))
+      javascript_dir = File.join(Rails.public_path, 'javascripts', asset_path('', frontend), ActiveScaffold.js_framework.to_s)
       Dir.entries(javascript_dir).reject { |e| !e.match(/\.js$/) or (!self.dhtml_history? and e.match('dhtml_history')) }
     end
 

--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -74,7 +74,7 @@ module ActiveScaffold
       #   <%= javascript_include_tag :defaults, 'your_own_cool_script', active_scaffold_javascripts, :cache => true %>
       def active_scaffold_javascripts(frontend = :default)
         ActiveScaffold::Config::Core.javascripts(frontend).collect do |name|
-          ActiveScaffold::Config::Core.asset_path(name, frontend)
+          ActiveScaffold::Config::Core.asset_path("#{ActiveScaffold.js_framework}/#{name}", frontend)
         end
       end
       
@@ -160,6 +160,7 @@ module ActiveScaffold
         html_options[:class] += " #{link.html_options[:class]}" unless link.html_options[:class].blank?
         html_options
       end
+
       def get_action_link_id(url_options, record = nil, column = nil)
         id = url_options[:id] || url_options[:parent_id]
         id = "#{column.association.name}-#{record.id}" if column && column.plural_association?

--- a/uninstall.rb
+++ b/uninstall.rb
@@ -1,5 +1,5 @@
 ##
-## Delete public asset files
+## Delete public asset files and configuration initializer
 ##
 
 require 'fileutils'
@@ -10,4 +10,8 @@ directory = File.dirname(__FILE__)
   path = File.join(directory, "../../../public/#{asset_type}/active_scaffold")
   FileUtils.rm_r(path)
 end
+
+# Remove initializer
+FileUtils.rm(File.join(directory, "../../../config/initializers/active_scaffold.rb"))
+
 FileUtils.rm(File.join(directory, "../../../public/blank.html"))


### PR DESCRIPTION
Intended behaviour :
- A new initializer is added by AS at startup to hold the JS framework configuration parameter ActiveScaffold.js_framework
- Both Prototype and jQuery files are copied over as assets, the right ones are picked up by <%= active_scaffold_includes %> depending on the configuration
- If no configuration is set an exception is raised (should _only_ happen when there was already an initializer named active_scaffold.rb)

As a result :
- AS works out of the box with a prototype enabled app (just have to add the AS includes)
- A single intializer parameter has to be modified to use jQuery (along /w the includes)

Left to do :
- Generator shouldn't hardcode the jQuery includes in the application layout, instead the generator should assume the app is already enabled for prototype/jquery and only add the include line, which will in turn pull the right includes automatically
