### PR TITLE
allow inplace editor to be inside some surrounding decorating tags

### DIFF
--- a/frontends/default/javascripts/jquery/active_scaffold.js
+++ b/frontends/default/javascripts/jquery/active_scaffold.js
@@ -140,7 +140,11 @@ $(document).ready(function() {
           csrf_token = $('meta[name=csrf-token]').first(),
           my_parent = span.parent(),
           column_heading = null;
-      
+
+      if(!(my_parent.is('td') || my_parent.is('th'))){
+          my_parent = span.parents('td').eq(0);
+      }
+
       if (my_parent.is('td')) {
         var column_no = my_parent.prevAll('td').length;
         column_heading = my_parent.closest('.active-scaffold').find('th:eq(' + column_no + ')');

--- a/frontends/default/javascripts/prototype/active_scaffold.js
+++ b/frontends/default/javascripts/prototype/active_scaffold.js
@@ -155,6 +155,10 @@ document.observe("dom:loaded", function() {
           csrf_token = $$('meta[name=csrf-token]')[0],
           my_parent = span.up(),
           column_heading = null;
+
+      if(!(my_parent.nodeName.toLowerCase() === 'td' || my_parent.nodeName.toLowerCase() === 'th')){
+          my_parent = span.up('td');
+      }
           
       if (my_parent.nodeName.toLowerCase() === 'td') {
         var heading_selector = '.' + span.up().readAttribute('class').split(' ')[0] + '_heading';


### PR DESCRIPTION
If we'd like to put a cell's content inside a decorator tag (say show an icon at the beginning via css) the `inplace_editor` breaks. My commit fixes this.
(Prototype version not tested, but is such a simple change that it should most definitely work!)
