### PR TITLE
build instead of new in edit_association

### DIFF
--- a/lib/active_scaffold/actions/subform.rb
+++ b/lib/active_scaffold/actions/subform.rb
@@ -6,7 +6,7 @@ module ActiveScaffold::Actions
 
       # NOTE: we don't check whether the user is allowed to update this record, because if not, we'll still let them associate the record. we'll just refuse to do more than associate, is all.
       @record = @column.association.klass.find(params[:associated_id]) if params[:associated_id]
-      @record ||= @column.association.klass.new
+      @record ||= @column.singular_association? ? @parent_record.send("build_#{@column.name}".to_sym) : @parent_record.send(@column.name).build
 
       @scope = "[#{@column.name}]"
       @scope += (@record.new_record?) ? "[#{(Time.now.to_f*1000).to_i.to_s}]" : "[#{@record.id}]" if @column.plural_association?


### PR DESCRIPTION
One more place needing it.

The `@column.singular_association? ? @parent_record.send("build_#{@column.name}".to_sym) : @parent_record.send(@column.name).build` should be refactored DRY sometime in the future because it looks awfully the same in all places.
