### PR TITLE
Don't show inplace_edit in list view when record isn't authorized for updates

### DIFF
--- a/lib/active_scaffold/helpers/list_column_helpers.rb
+++ b/lib/active_scaffold/helpers/list_column_helpers.rb
@@ -140,7 +140,7 @@ module ActiveScaffold
       end
 
       def column_override(column)
-        "#{(column.active_record_class.name)}_#{column.name.to_s.gsub('?', '')}_column" # parse out any question marks (see issue 227)
+        "#{(column.active_record_class.name.downcase)}_#{column.name.to_s.gsub('?', '')}_column" # parse out any question marks (see issue 227)
       end
 
       def column_override?(column)


### PR DESCRIPTION
Without this, you're offered the ability to update the data, but it's not saved and no reason is offered.

This seems to be the best place to put the logic, but I'm open to alternatives.
