### PR TITLE
Allow controller configuration per assoc, no matter if the assoc's use the same model class

### DIFF
--- a/lib/active_scaffold.rb
+++ b/lib/active_scaffold.rb
@@ -237,9 +237,9 @@ module ActiveScaffold
       end
     end
     
-    def link_for_association(column, options = {})
+    def active_scaffold_controller_for_column(column, options = {})
       begin
-        controller = if column.polymorphic_association?
+        if column.polymorphic_association?
           :polymorph
         elsif options.include?(:controller)
           "#{options[:controller].to_s.camelize}Controller".constantize
@@ -247,8 +247,12 @@ module ActiveScaffold
           active_scaffold_controller_for(column.association.klass)
         end
       rescue ActiveScaffold::ControllerNotFound
-        controller = nil        
+        nil        
       end
+    end
+    
+    def link_for_association(column, options = {})
+      controller = active_scaffold_controller_for_column(column, options)
       
       unless controller.nil?
         options.reverse_merge! :label => column.label, :position => :after, :type => :member, :controller => (controller == :polymorph ? controller : controller.controller_path), :column => column


### PR DESCRIPTION
Say we have:

```
Role has_one :global_permission, :class => Permission
Role has_many :local_permissions, :class => Permission
```

And we want each assoc to use a different controller ie. `GlobalPermissionsController` and `LocalPermissionsController`.

We cannot override `active_scaffold_controller_for(klass)` as it calls with the same class (Permission) and we cannot differentiate.

One way would be to override the `link_for_association(column, options = {})` method. But it's a fat method and what we want to override is just the top logic that chooses the controller.

My pull refactors `link_for_association` to allow just this overriding via `active_scaffold_controller_for_column`, and have an easy way to choose controller based on association.
