### PR TITLE
Paperclip bridge helper overwrites existing methods

### DIFF
--- a/lib/active_scaffold/bridges/paperclip/lib/paperclip_bridge_helpers.rb
+++ b/lib/active_scaffold/bridges/paperclip/lib/paperclip_bridge_helpers.rb
@@ -7,7 +7,7 @@ module ActiveScaffold
           self.thumbnail_style = :thumbnail
         
           def self.generate_delete_helper(klass, field)
-            klass.class_eval <<-EOF, __FILE__, __LINE__ + 1 unless klass.methods.include?("delete_#{field}=")
+            klass.class_eval <<-EOF, __FILE__, __LINE__ + 1 unless klass.instance_methods.include?("delete_#{field}=")
               attr_reader :delete_#{field}
         
               def delete_#{field}=(value)


### PR DESCRIPTION
This fixes the conditional guard to check against instance methods rather than class methods before defining the delete_<i>attachment</i> methods.
