### PR TITLE
StringComparators should use ILIKE on postgresql

### DIFF
--- a/lib/active_scaffold/finder.rb
+++ b/lib/active_scaffold/finder.rb
@@ -93,7 +93,7 @@ module ActiveScaffold
         elsif value[:from].blank?
           nil
         elsif ActiveScaffold::Finder::StringComparators.values.include?(value[:opt])
-          ["#{column.search_sql} LIKE ?", value[:opt].sub('?', value[:from])]
+          ["#{column.search_sql} #{ActiveScaffold::Finder.like_operator} ?", value[:opt].sub('?', value[:from])]
         elsif value[:opt] == 'BETWEEN'
           ["#{column.search_sql} BETWEEN ? AND ?", value[:from], value[:to]]
         elsif ActiveScaffold::Finder::NumericComparators.include?(value[:opt])


### PR DESCRIPTION
When using postgres, the StringComparators ("contains" especially) should be case insensitive. 

This patch, at the very least, allows this behavior to be somewhat configurable, by overriding the like_operator method. 
