### PR TITLE
Fixing bundler dependency problem with rails 3.1.0

### DIFF
--- a/active_scaffold_vho.gemspec
+++ b/active_scaffold_vho.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{active_scaffold_vho}
-  s.version = "3.1.0.rc1"
+  s.version = "3.1.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Many, see README"]


### PR DESCRIPTION
I simply changed '3.1.0' with '3.1.0.rc1', and this removed by bundle install errors.  I am using rails 3.1.0.rc6.

A similar change is also required in render_component.
